### PR TITLE
Add minimal FastAPI course platform skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
+Visit `http://localhost:8000/` for a simple HTML preview of courses or
+`http://localhost:8000/docs` for the interactive API docs.
+
 ## Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Mini Teachable Platform
+
+This repository contains a minimal FastAPI application that mimics basic features of a Teachable-like platform.
+
+## Features
+- List existing courses
+- Create new courses
+- Retrieve course details
+- Add lessons to a course
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, HTTPException
+from typing import List
+
+from .models import Course, CourseCreate, Lesson
+
+app = FastAPI(title="Mini Teachable API")
+
+courses: List[Course] = []
+course_id_counter = 1
+
+
+@app.get("/courses", response_model=List[Course])
+def list_courses() -> List[Course]:
+    return courses
+
+
+@app.post("/courses", response_model=Course, status_code=201)
+def create_course(course: CourseCreate) -> Course:
+    global course_id_counter
+    new_course = Course(id=course_id_counter, title=course.title, description=course.description, lessons=[])
+    course_id_counter += 1
+    courses.append(new_course)
+    return new_course
+
+
+@app.get("/courses/{course_id}", response_model=Course)
+def get_course(course_id: int) -> Course:
+    for c in courses:
+        if c.id == course_id:
+            return c
+    raise HTTPException(status_code=404, detail="Course not found")
+
+
+@app.post("/courses/{course_id}/lessons", response_model=Course)
+def add_lesson(course_id: int, lesson: Lesson) -> Course:
+    for c in courses:
+        if c.id == course_id:
+            lesson_id = len(c.lessons) + 1
+            c.lessons.append(Lesson(id=lesson_id, title=lesson.title, content=lesson.content))
+            return c
+    raise HTTPException(status_code=404, detail="Course not found")

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
 from typing import List
 
 from .models import Course, CourseCreate, Lesson
@@ -7,6 +8,15 @@ app = FastAPI(title="Mini Teachable API")
 
 courses: List[Course] = []
 course_id_counter = 1
+
+
+@app.get("/", response_class=HTMLResponse)
+def home() -> str:
+    items = "".join(f"<li>{c.title}</li>" for c in courses)
+    return (
+        "<html><head><title>Mini Teachable</title></head><body>"
+        "<h1>Courses</h1><ul>" + items + "</ul></body></html>"
+    )
 
 
 @app.get("/courses", response_model=List[Course])

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class Lesson(BaseModel):
+    id: int
+    title: str
+    content: str
+
+
+class Course(BaseModel):
+    id: int
+    title: str
+    description: str
+    lessons: List[Lesson] = []
+
+
+class CourseCreate(BaseModel):
+    title: str
+    description: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+pytest

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-#comment

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,32 @@
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+import app.main as main
+
+
+@pytest.fixture
+def client():
+    importlib.reload(main)
+    return TestClient(main.app)
+
+
+def test_create_and_get_course(client):
+    response = client.post("/courses", json={"title": "Test Course", "description": "Desc"})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] == 1
+    assert data["title"] == "Test Course"
+
+    response = client.get("/courses/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Test Course"
+
+
+def test_list_courses(client):
+    client.post("/courses", json={"title": "Course1", "description": "Desc"})
+    client.post("/courses", json={"title": "Course2", "description": "Desc"})
+    response = client.get("/courses")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,3 +30,10 @@ def test_list_courses(client):
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
+
+
+def test_homepage_lists_courses(client):
+    client.post("/courses", json={"title": "HTML Course", "description": "Desc"})
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "HTML Course" in response.text


### PR DESCRIPTION
## Summary
- implement basic FastAPI app with course and lesson models
- add tests demonstrating course creation and listing
- ignore Python cache

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a6f6aff600832cb263ede359404708